### PR TITLE
same quant used for thumbs extraction args is depreciated 

### DIFF
--- a/slowmoVideo/project/videoFrameSource_sV.cpp
+++ b/slowmoVideo/project/videoFrameSource_sV.cpp
@@ -123,7 +123,7 @@ void VideoFrameSource_sV::extractFramesFor(const FrameSize frameSize, QProcess *
     QStringList args;
     args << "-i" << m_inFile.fileName();
     args << "-f" << "image2";
-    args << m_avconvInfo.optionSameQuant();
+    args << "-qscale" << "0";
 
     if (frameSize == FrameSize_Small) {
         int w = m_videoInfo->width;


### PR DESCRIPTION
Using -quant 0 instead for both ffmpeg / avconv
